### PR TITLE
refactor(sidecar): split AI tool schemas and handlers

### DIFF
--- a/sidecar/src/packet_pilot_ai/services/__init__.py
+++ b/sidecar/src/packet_pilot_ai/services/__init__.py
@@ -2,5 +2,7 @@
 
 from . import rust_bridge
 from . import ai_agent
+from . import ai_tools
+from . import ai_tool_handlers
 
-__all__ = ["rust_bridge", "ai_agent"]
+__all__ = ["rust_bridge", "ai_agent", "ai_tools", "ai_tool_handlers"]

--- a/sidecar/src/packet_pilot_ai/services/ai_tool_handlers.py
+++ b/sidecar/src/packet_pilot_ai/services/ai_tool_handlers.py
@@ -1,0 +1,311 @@
+"""Tool execution handlers for PacketPilot AI agent."""
+
+from dataclasses import dataclass
+from typing import Any, Awaitable, Callable
+
+ToolExecutor = Callable[[dict[str, Any]], Awaitable[str]]
+BridgeMethod = Callable[..., Awaitable[Any]]
+
+
+@dataclass(frozen=True)
+class ToolRuntime:
+    """Runtime dependencies used by tool handlers."""
+
+    search_packets: BridgeMethod
+    get_stream: BridgeMethod
+    get_capture_stats: BridgeMethod
+    get_frame_details: BridgeMethod
+    find_anomalies: BridgeMethod
+    get_packet_context: BridgeMethod
+    compare_packets: BridgeMethod
+
+
+async def _execute_search_packets_tool(arguments: dict[str, Any], runtime: ToolRuntime) -> str:
+    result = await runtime.search_packets(
+        filter_str=arguments["filter"],
+        limit=arguments.get("limit", 50),
+    )
+    if result:
+        frames = result.get("frames", [])
+        total = result.get("total_matching", 0)
+        if frames:
+            summary = f"Found {total} packets matching '{arguments['filter']}'. Showing first {len(frames)}:\n"
+            for frame in frames[:20]:
+                summary += (
+                    f"  #{frame.get('number', '?')}: {frame.get('protocol', '?')} "
+                    f"{frame.get('source', '?')} -> {frame.get('destination', '?')} "
+                    f"| {frame.get('info', '')[:80]}\n"
+                )
+            return summary
+        return f"No packets found matching '{arguments['filter']}'"
+    return "Error executing search"
+
+
+async def _execute_get_stream_tool(arguments: dict[str, Any], runtime: ToolRuntime) -> str:
+    result = await runtime.get_stream(
+        stream_id=arguments["stream_id"],
+        protocol=arguments.get("protocol", "TCP"),
+        format="ascii",
+    )
+    if result:
+        server = result.get("server", {})
+        client = result.get("client", {})
+        combined = result.get("combined_text", "")
+        if len(combined) > 4000:
+            combined = combined[:4000] + "\n... [truncated]"
+        return (
+            f"Stream {arguments['stream_id']} ({arguments.get('protocol', 'TCP')}):\n"
+            f"Server: {server.get('host', '?')}:{server.get('port', '?')}\n"
+            f"Client: {client.get('host', '?')}:{client.get('port', '?')}\n\n"
+            f"{combined}"
+        )
+    return "Error fetching stream or stream not found"
+
+
+async def _execute_get_packet_details_tool(arguments: dict[str, Any], runtime: ToolRuntime) -> str:
+    result = await runtime.get_frame_details(arguments["packet_num"])
+    if result:
+        tree = result.get("tree", [])
+        output = f"Packet #{arguments['packet_num']} details:\n"
+        for node in tree[:10]:
+            label = node.get("l", "")
+            if label:
+                output += f"  - {label}\n"
+        return output
+    return "Error fetching packet details"
+
+
+async def _execute_find_anomalies_tool(arguments: dict[str, Any], runtime: ToolRuntime) -> str:
+    result = await runtime.find_anomalies(
+        types=arguments.get("types"),
+        limit_per_type=10,
+    )
+    summary = result.get("summary", {})
+    anomalies = result.get("anomalies", [])
+
+    if summary.get("total_anomalies", 0) == 0:
+        return "No anomalies detected in the capture. The network traffic appears healthy."
+
+    output = f"Found {summary['total_anomalies']} anomalies:\n"
+    output += f"  - Errors: {summary['by_severity']['error']}\n"
+    output += f"  - Warnings: {summary['by_severity']['warning']}\n"
+    output += f"  - Info: {summary['by_severity']['info']}\n\n"
+
+    for anomaly in anomalies:
+        severity_icon = {"error": "🔴", "warning": "🟡", "info": "🔵"}.get(anomaly["severity"], "")
+        output += f"{severity_icon} {anomaly['type'].upper()} ({anomaly['count']} packets)\n"
+        output += f"   {anomaly['description']}\n"
+        if anomaly.get("sample_packets"):
+            output += "   Sample packets:\n"
+            for packet in anomaly["sample_packets"][:3]:
+                output += (
+                    f"     #{packet['number']}: {packet['source']} -> {packet['destination']} "
+                    f"| {packet['info']}\n"
+                )
+        output += "\n"
+
+    return output
+
+
+async def _execute_get_packet_context_tool(arguments: dict[str, Any], runtime: ToolRuntime) -> str:
+    result = await runtime.get_packet_context(
+        packet_num=arguments["packet_num"],
+        before=arguments.get("before", 5),
+        after=arguments.get("after", 5),
+    )
+    if not result:
+        return f"Error fetching context for packet #{arguments['packet_num']}"
+
+    output = f"Context around packet #{arguments['packet_num']}:\n\n"
+
+    before_packets = result.get("before", [])
+    if before_packets:
+        output += "BEFORE:\n"
+        for packet in before_packets:
+            output += (
+                f"  #{packet['number']}: {packet['protocol']} {packet['source']} -> "
+                f"{packet['destination']} | {packet['info']}\n"
+            )
+        output += "\n"
+
+    target = result.get("target", {})
+    target_summary = target.get("summary", {})
+    output += f">>> TARGET #{target_summary.get('number', '?')}:\n"
+    output += (
+        f"    {target_summary.get('protocol', '?')} {target_summary.get('source', '?')} -> "
+        f"{target_summary.get('destination', '?')}\n"
+    )
+    output += f"    {target_summary.get('info', '')}\n"
+
+    details = target.get("details", {})
+    tree = details.get("tree", [])
+    if tree:
+        output += "    Details:\n"
+        for node in tree[:6]:
+            label = node.get("l", "")
+            if label:
+                output += f"      - {label}\n"
+    output += "\n"
+
+    after_packets = result.get("after", [])
+    if after_packets:
+        output += "AFTER:\n"
+        for packet in after_packets:
+            output += (
+                f"  #{packet['number']}: {packet['protocol']} {packet['source']} -> "
+                f"{packet['destination']} | {packet['info']}\n"
+            )
+
+    return output
+
+
+async def _execute_compare_packets_tool(arguments: dict[str, Any], runtime: ToolRuntime) -> str:
+    result = await runtime.compare_packets(
+        packet_a=arguments["packet_a"],
+        packet_b=arguments["packet_b"],
+    )
+    if not result:
+        return f"Error comparing packets #{arguments['packet_a']} and #{arguments['packet_b']}"
+
+    packet_a = result.get("packet_a", {})
+    packet_b = result.get("packet_b", {})
+
+    output = f"Comparison of packet #{arguments['packet_a']} vs #{arguments['packet_b']}:\n\n"
+
+    output += f"Packet A (#{packet_a.get('number', '?')}):\n"
+    output += f"  {packet_a.get('protocol', '?')} {packet_a.get('source', '?')} -> {packet_a.get('destination', '?')}\n"
+    output += f"  {packet_a.get('info', '')}\n\n"
+
+    output += f"Packet B (#{packet_b.get('number', '?')}):\n"
+    output += f"  {packet_b.get('protocol', '?')} {packet_b.get('source', '?')} -> {packet_b.get('destination', '?')}\n"
+    output += f"  {packet_b.get('info', '')}\n\n"
+
+    output += f"Common fields: {result.get('common_fields', 0)}\n"
+    output += f"Different fields: {result.get('different_fields', 0)}\n\n"
+
+    differences = result.get("differences", {})
+    if differences:
+        output += "KEY DIFFERENCES:\n"
+        important_keys = ["Sequence Number", "Acknowledgment Number", "Time", "Length", "Flags"]
+        shown = 0
+        for key in important_keys:
+            if key in differences and shown < 10:
+                diff = differences[key]
+                output += f"  {key}:\n"
+                output += f"    A: {diff.get('packet_a', 'N/A')}\n"
+                output += f"    B: {diff.get('packet_b', 'N/A')}\n"
+                shown += 1
+
+        for key, diff in list(differences.items())[:15 - shown]:
+            if key not in important_keys:
+                output += f"  {key}:\n"
+                output += f"    A: {diff.get('packet_a', 'N/A')}\n"
+                output += f"    B: {diff.get('packet_b', 'N/A')}\n"
+
+    return output
+
+
+async def _execute_get_capture_overview_tool(_arguments: dict[str, Any], runtime: ToolRuntime) -> str:
+    result = await runtime.get_capture_stats()
+    if result:
+        summary = result.get("summary", {})
+        hierarchy = result.get("protocol_hierarchy", [])
+
+        output = "CAPTURE OVERVIEW:\n"
+        output += f"  Total frames: {summary.get('total_frames', 0)}\n"
+        if summary.get("duration"):
+            output += f"  Duration: {summary.get('duration'):.2f} seconds\n"
+        output += f"  TCP conversations: {summary.get('tcp_conversation_count', 0)}\n"
+        output += f"  UDP conversations: {summary.get('udp_conversation_count', 0)}\n"
+        output += f"  Endpoints: {summary.get('endpoint_count', 0)}\n\n"
+
+        output += "PROTOCOL HIERARCHY:\n"
+        for proto in hierarchy[:10]:
+            frames = proto.get("frames", 0)
+            bytes_count = proto.get("bytes", 0)
+            output += f"  - {proto.get('protocol', '?')}: {frames} packets, {bytes_count} bytes\n"
+            for child in proto.get("children", [])[:3]:
+                output += f"    - {child.get('protocol', '?')}: {child.get('frames', 0)} packets\n"
+
+        return output
+    return "Error fetching capture overview"
+
+
+async def _execute_get_conversations_tool(arguments: dict[str, Any], runtime: ToolRuntime) -> str:
+    result = await runtime.get_capture_stats()
+    if result:
+        protocol = arguments.get("protocol", "both")
+        limit = arguments.get("limit", 20)
+
+        output = "NETWORK CONVERSATIONS:\n\n"
+
+        if protocol in ["tcp", "both"]:
+            tcp_conversations = result.get("tcp_conversations", [])[:limit]
+            if tcp_conversations:
+                output += f"TCP CONVERSATIONS ({len(tcp_conversations)} shown):\n"
+                for conversation in tcp_conversations:
+                    total_bytes = conversation.get("rx_bytes", 0) + conversation.get("tx_bytes", 0)
+                    total_frames = conversation.get("rx_frames", 0) + conversation.get("tx_frames", 0)
+                    src = f"{conversation.get('src_addr', '?')}:{conversation.get('src_port', '?')}"
+                    dst = f"{conversation.get('dst_addr', '?')}:{conversation.get('dst_port', '?')}"
+                    output += f"  {src} <-> {dst}\n"
+                    output += f"    {total_frames} packets, {total_bytes} bytes\n"
+                output += "\n"
+
+        if protocol in ["udp", "both"]:
+            udp_conversations = result.get("udp_conversations", [])[:limit]
+            if udp_conversations:
+                output += f"UDP CONVERSATIONS ({len(udp_conversations)} shown):\n"
+                for conversation in udp_conversations:
+                    total_bytes = conversation.get("rx_bytes", 0) + conversation.get("tx_bytes", 0)
+                    total_frames = conversation.get("rx_frames", 0) + conversation.get("tx_frames", 0)
+                    src = f"{conversation.get('src_addr', '?')}:{conversation.get('src_port', '?')}"
+                    dst = f"{conversation.get('dst_addr', '?')}:{conversation.get('dst_port', '?')}"
+                    output += f"  {src} <-> {dst}\n"
+                    output += f"    {total_frames} packets, {total_bytes} bytes\n"
+
+        if output.strip() == "NETWORK CONVERSATIONS:":
+            return "No conversations found"
+        return output
+    return "Error fetching conversations"
+
+
+async def _execute_get_endpoints_tool(arguments: dict[str, Any], runtime: ToolRuntime) -> str:
+    result = await runtime.get_capture_stats()
+    if result:
+        limit = arguments.get("limit", 20)
+        endpoints = result.get("endpoints", [])[:limit]
+
+        if endpoints:
+            sorted_endpoints = sorted(
+                endpoints,
+                key=lambda endpoint: endpoint.get("rx_bytes", 0) + endpoint.get("tx_bytes", 0),
+                reverse=True,
+            )
+            output = f"TOP ENDPOINTS ({len(sorted_endpoints)} shown):\n\n"
+            for endpoint in sorted_endpoints:
+                host = endpoint.get("host", "?")
+                port = endpoint.get("port")
+                addr = f"{host}:{port}" if port else host
+                output += f"  {addr}:\n"
+                output += f"    TX: {endpoint.get('tx_frames', 0)} pkts, {endpoint.get('tx_bytes', 0)} bytes\n"
+                output += f"    RX: {endpoint.get('rx_frames', 0)} pkts, {endpoint.get('rx_bytes', 0)} bytes\n"
+            return output
+        return "No endpoints found"
+    return "Error fetching endpoints"
+
+
+def build_tool_executors(runtime: ToolRuntime) -> dict[str, ToolExecutor]:
+    """Build tool dispatch map for the current runtime dependencies."""
+
+    return {
+        "search_packets": lambda arguments: _execute_search_packets_tool(arguments, runtime),
+        "get_stream": lambda arguments: _execute_get_stream_tool(arguments, runtime),
+        "get_packet_details": lambda arguments: _execute_get_packet_details_tool(arguments, runtime),
+        "find_anomalies": lambda arguments: _execute_find_anomalies_tool(arguments, runtime),
+        "get_packet_context": lambda arguments: _execute_get_packet_context_tool(arguments, runtime),
+        "compare_packets": lambda arguments: _execute_compare_packets_tool(arguments, runtime),
+        "get_capture_overview": lambda arguments: _execute_get_capture_overview_tool(arguments, runtime),
+        "get_conversations": lambda arguments: _execute_get_conversations_tool(arguments, runtime),
+        "get_endpoints": lambda arguments: _execute_get_endpoints_tool(arguments, runtime),
+    }

--- a/sidecar/src/packet_pilot_ai/services/ai_tools.py
+++ b/sidecar/src/packet_pilot_ai/services/ai_tools.py
@@ -1,0 +1,302 @@
+"""Tool schemas and constraints for AI function-calling."""
+
+# Tool definitions for AI function calling
+TOOLS = [
+    # === OVERVIEW TOOLS (start here for exploration) ===
+    {
+        "type": "function",
+        "function": {
+            "name": "get_capture_overview",
+            "description": """Get a high-level overview of the entire capture.
+
+RETURNS: Total packets, duration, protocol hierarchy, conversation counts, endpoint counts.
+
+WHEN TO USE: Start here when you need to understand the capture before drilling down.
+- "What's in this capture?"
+- "Give me an overview"
+- "What protocols are being used?"
+- Any exploratory analysis
+
+EXAMPLE: User asks "What kind of traffic is in this capture?" -> Use this first, then search for specific protocols.""",
+            "parameters": {
+                "type": "object",
+                "properties": {},
+                "required": []
+            }
+        }
+    },
+    {
+        "type": "function",
+        "function": {
+            "name": "get_conversations",
+            "description": """List network conversations (connections between endpoints).
+
+RETURNS: TCP and/or UDP conversations with addresses, ports, packet/byte counts.
+
+WHEN TO USE: When you need to see who is talking to whom.
+- "Show me the connections"
+- "What hosts are communicating?"
+- "Find the largest data transfers"
+- "Who is this IP talking to?"
+
+EXAMPLE: User asks about connections from 192.168.1.100 -> Use this to list conversations.""",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "protocol": {
+                        "type": "string",
+                        "enum": ["tcp", "udp", "both"],
+                        "description": "Filter by protocol (default: both)",
+                        "default": "both"
+                    },
+                    "limit": {
+                        "type": "integer",
+                        "description": "Max conversations to return (default 20)",
+                        "default": 20
+                    }
+                },
+                "required": []
+            }
+        }
+    },
+    {
+        "type": "function",
+        "function": {
+            "name": "get_endpoints",
+            "description": """List top network endpoints (hosts) by traffic volume.
+
+RETURNS: IP addresses with packets sent/received and bytes sent/received.
+
+WHEN TO USE: When you need to identify the most active hosts.
+- "What are the busiest hosts?"
+- "Who is sending the most data?"
+- "List all IPs in this capture"
+- "Find the top talkers"
+
+EXAMPLE: User asks "Which host is generating the most traffic?" -> Use this.""",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "limit": {
+                        "type": "integer",
+                        "description": "Max endpoints to return (default 20)",
+                        "default": 20
+                    }
+                },
+                "required": []
+            }
+        }
+    },
+    # === SEARCH & INSPECT TOOLS (drill down) ===
+    {
+        "type": "function",
+        "function": {
+            "name": "search_packets",
+            "description": """Search packets using a Wireshark display filter expression.
+
+RETURNS: List of matching packets with frame number, protocol, addresses, and info.
+
+WHEN TO USE: When you need to find specific packets. Use after overview to drill down.
+
+FILTER EXAMPLES:
+- Protocol: 'http', 'dns', 'tcp', 'tls'
+- IP: 'ip.addr == 192.168.1.1', 'ip.src == 10.0.0.1'
+- Port: 'tcp.port == 443', 'udp.port == 53'
+- Flags: 'tcp.flags.syn == 1', 'tcp.flags.rst == 1'
+- Combined: 'http.request && ip.dst == 10.0.0.1'
+- Content: 'http.request.uri contains "api"'""",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "filter": {
+                        "type": "string",
+                        "description": "Wireshark display filter (e.g., 'http.request', 'tcp.port == 443')"
+                    },
+                    "limit": {
+                        "type": "integer",
+                        "description": "Max packets to return (default 50)",
+                        "default": 50
+                    }
+                },
+                "required": ["filter"]
+            }
+        }
+    },
+    {
+        "type": "function",
+        "function": {
+            "name": "get_stream",
+            "description": """Reconstruct the full content of a TCP, UDP, or HTTP conversation.
+
+RETURNS: Complete data exchanged between client and server.
+
+WHEN TO USE: When you need to see actual payload data, not just headers.
+- "What data was sent to the server?"
+- "Show me the HTTP response body"
+- "What did they download?"
+
+WORKFLOW: First search_packets to find traffic, note the stream number, then use this.""",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "stream_id": {
+                        "type": "integer",
+                        "description": "Stream index (from packet info, e.g., tcp.stream=0)"
+                    },
+                    "protocol": {
+                        "type": "string",
+                        "enum": ["TCP", "UDP", "HTTP"],
+                        "description": "Protocol type (default TCP)",
+                        "default": "TCP"
+                    }
+                },
+                "required": ["stream_id"]
+            }
+        }
+    },
+    {
+        "type": "function",
+        "function": {
+            "name": "get_packet_details",
+            "description": """Get detailed protocol dissection for a specific packet.
+
+RETURNS: Full protocol tree with all layers and field values.
+
+WHEN TO USE: When you need to examine one packet in detail.
+- After finding a packet of interest via search
+- To see all protocol fields and flags
+- To examine packet payload""",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "packet_num": {
+                        "type": "integer",
+                        "description": "Frame number of the packet"
+                    }
+                },
+                "required": ["packet_num"]
+            }
+        }
+    },
+    # === ANALYSIS TOOLS ===
+    {
+        "type": "function",
+        "function": {
+            "name": "find_anomalies",
+            "description": """Detect network anomalies and issues in the capture.
+
+RETURNS: Summary of issues with severity and sample packets.
+
+WHEN TO USE: For quick health checks or troubleshooting.
+- "Is there anything wrong?"
+- "Why is it slow?"
+- "Are there any errors?"
+
+DETECTS: retransmissions, duplicate ACKs, resets, zero window, malformed packets, ICMP errors, DNS errors, HTTP 4xx/5xx, TLS alerts""",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "types": {
+                        "type": "array",
+                        "items": {"type": "string"},
+                        "description": "Specific types to check (omit for all): retransmission, reset, dns_error, http_error, tls_alert, etc."
+                    }
+                },
+                "required": []
+            }
+        }
+    },
+    {
+        "type": "function",
+        "function": {
+            "name": "get_packet_context",
+            "description": """Get a packet with surrounding packets for context.
+
+RETURNS: Target packet plus packets before and after it.
+
+WHEN TO USE: To understand what happened around a specific event.
+- "What caused this reset?"
+- "What happened before the error?"
+- Analyzing sequences and timing""",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "packet_num": {
+                        "type": "integer",
+                        "description": "Frame number of the target packet"
+                    },
+                    "before": {
+                        "type": "integer",
+                        "description": "Packets before to include (default 5)",
+                        "default": 5
+                    },
+                    "after": {
+                        "type": "integer",
+                        "description": "Packets after to include (default 5)",
+                        "default": 5
+                    }
+                },
+                "required": ["packet_num"]
+            }
+        }
+    },
+    {
+        "type": "function",
+        "function": {
+            "name": "compare_packets",
+            "description": """Compare two packets field by field.
+
+RETURNS: Differences between the packets.
+
+WHEN TO USE: To analyze related packets.
+- Compare request vs response
+- Compare original vs retransmission
+- Find what changed between two similar packets""",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "packet_a": {
+                        "type": "integer",
+                        "description": "Frame number of first packet"
+                    },
+                    "packet_b": {
+                        "type": "integer",
+                        "description": "Frame number of second packet"
+                    }
+                },
+                "required": ["packet_a", "packet_b"]
+            }
+        }
+    }
+]
+
+
+TOOL_SCHEMAS = {
+    tool["function"]["name"]: tool["function"].get("parameters", {})
+    for tool in TOOLS
+}
+
+TOOL_NUMERIC_BOUNDS: dict[str, dict[str, tuple[int | None, int | None]]] = {
+    "search_packets": {"limit": (1, 200)},
+    "get_stream": {"stream_id": (0, 1000000)},
+    "get_packet_details": {"packet_num": (1, 100000000)},
+    "get_packet_context": {
+        "packet_num": (1, 100000000),
+        "before": (0, 50),
+        "after": (0, 50),
+    },
+    "compare_packets": {
+        "packet_a": (1, 100000000),
+        "packet_b": (1, 100000000),
+    },
+    "get_conversations": {"limit": (1, 100)},
+    "get_endpoints": {"limit": (1, 100)},
+}
+
+TOOL_GUARDRAIL_PHRASES = (
+    "ignore previous instructions",
+    "system prompt",
+    "developer message",
+    "openrouter_api_key",
+    "api key",
+)


### PR DESCRIPTION
## Summary
- extract AI tool schema/constraints into `sidecar/src/packet_pilot_ai/services/ai_tools.py`
- extract tool execution handlers into `sidecar/src/packet_pilot_ai/services/ai_tool_handlers.py`
- keep orchestration in `ai_agent.py` and wire runtime dispatch via `build_tool_executors(...)`
- preserve existing monkeypatch compatibility by binding runtime from `ai_agent` module-level bridge functions at call time
- export new modules from `sidecar/src/packet_pilot_ai/services/__init__.py`

## Verification
- `.venv/bin/pytest tests/unit/test_tool_execution.py tests/integration/test_analyze_flow.py -q`
- result: `36 passed`
